### PR TITLE
Delete CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,9 +1,0 @@
-# Code owners of CB-Tumblebug
-
-# These owners will be the default owners for everything in this repo. 
-# They will be requested for review when someone opens a pull request.
-*       @seokho-son @jihoon-seo
-
-# These subderectory owners own any files in the .github/
-# directory which includes github workflows.
-/.github/workflows/**  @jihoon-seo @hermitkim1 @seokho-son


### PR DESCRIPTION
CICD PoC 진행 시, TB 코드에는 변경사항이 없으며 리뷰도 필요하지 않을 것으로 보이므로 CODEOWNERS 파일을 삭제합니다. 😊